### PR TITLE
Allow tests to pass if `src` doesn't throw

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -7,7 +7,7 @@ import pkg from '../package.json';
 
 describe('main', function () {
   it('should have been changed', () => {
-    expect(src()).to.not.throw();
+    expect(() => src()).to.not.throw();
   });
 
   describe('package.json', function () {


### PR DESCRIPTION
I'm sure everyone will just delete this test file entirely, but I noticed this and it's a quick fix.

If you remove the `throw` from `src`, the tests still won't pass. You need to pass a `Function` object to `expect` in order to assert that a function doesn't throw, rather than passing the result of a function call. See the docs here: https://www.chaijs.com/api/bdd/#method_throw